### PR TITLE
Receiving categories from productQuery and added loading validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- receiving categories from productQuery and added loading validation.
 
 ## [0.1.2] - 2018-07-10
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.3] - 2018-07-19
 ### Fixed
 - receiving categories from productQuery and added loading validation.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "breadcrumb",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "title": "VTEX Breadcrumb",
   "description": "Breadcrumb Component",
   "defaultLocale": "pt-BR",

--- a/react/Breadcrumb.js
+++ b/react/Breadcrumb.js
@@ -28,7 +28,9 @@ class Breadcrumb extends Component {
   }
 
   getCategories(categories) {
-    const categoriesSorted = categories.slice().sort((a, b) => a.length - b.length)
+    const categoriesSorted = categories
+      .slice()
+      .sort((a, b) => a.length - b.length)
     return categoriesSorted.map(category => {
       const categoryStripped = category.replace(/^\//, '').replace(/\/$/, '')
       const categories = categoryStripped.split('/')
@@ -42,7 +44,14 @@ class Breadcrumb extends Component {
   }
 
   render() {
-    const { slug, categories } = this.props
+    const { slug, productQuery } = this.props
+
+    if (productQuery.loading || !productQuery.product.categories) {
+      return null
+    }
+
+    const { categories } = productQuery.product
+
     const categoriesList = this.getCategories(categories)
     return (
       <div className={CSS_CLASSES.BREADCRUMB}>
@@ -71,9 +80,16 @@ Breadcrumb.propTypes = {
   search: PropTypes.string,
   /** Product's slug**/
   slug: PropTypes.string,
-  /** Categories*/
-  categories: PropTypes.arrayOf(PropTypes.string),
+  /** Product data**/
+  productQuery: {
+    /** Product**/
+    product: PropTypes.shape({
+      /** Categories*/
+      categories: PropTypes.arrayOf(PropTypes.string),
+    }),
+    /** Loading**/
+    loading: PropTypes.bool.isRequired,
+  },
 }
 
 export default injectIntl(Breadcrumb)
-


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix breadcrumbs to receive data from productQuery props.

#### What problem is this solving?

Now the component should check if the data still loading or not before rendering.

#### How should this be manually tested?

[workspace](https://breadcrumbs--storecomponents.myvtex.com/nintendo-switch/p)

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
