### PR TITLE
Add default padding matching the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Default padding matching the page.
 
 ## [0.2.1] - 2018-08-10
 ## Changed

--- a/react/Breadcrumb.js
+++ b/react/Breadcrumb.js
@@ -1,9 +1,9 @@
-import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
+import React, { Component, Fragment } from 'react'
 import { Link } from 'render'
 
-import HomeIcon from './icons/HomeIcon'
 import ArrowIcon from './icons/ArrowIcon'
+import HomeIcon from './icons/HomeIcon'
 
 const LINK_CLASS_NAME =
   'vtex-breadcrumb__link dib pv1 link ph2 gray hover-near-black'
@@ -37,7 +37,7 @@ class Breadcrumb extends Component {
 
     const categoriesList = this.getCategories(categories)
     return (
-      <div className="vtex-breadcrumb pa4 gray">
+      <div className="vtex-breadcrumb vtex-page-padding pb4 pt4 gray">
         <Link className={LINK_CLASS_NAME} page="store">
           <HomeIcon />
         </Link>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add default padding matching the page

#### What problem is this solving?

Breadcrumbs had a different padding

#### How should this be manually tested?
[Access the workspace](https://padding--storecomponents.myvtex.com/porsche-911/p) and change the page's size.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/15948386/45313598-bb801f00-b505-11e8-9b3d-722ad017a5ec.png)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
