### PR TITLE
Remove page padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Remove page padding.
 
 ## [0.2.2] - 2018-09-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.3] - 2018-09-14
 ### Removed
 - Remove page padding.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "breadcrumb",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "title": "VTEX Breadcrumb",
   "description": "Breadcrumb Component",
   "defaultLocale": "pt-BR",

--- a/react/Breadcrumb.js
+++ b/react/Breadcrumb.js
@@ -37,7 +37,7 @@ class Breadcrumb extends Component {
 
     const categoriesList = this.getCategories(categories)
     return (
-      <div className="vtex-breadcrumb vtex-page-padding pb4 pt4 gray">
+      <div className="vtex-breadcrumb pb4 pt4 gray">
         <Link className={LINK_CLASS_NAME} page="store">
           <HomeIcon />
         </Link>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove the `vtex-page-padding` class.

#### What problem is this solving?
The breadcrumb shouldn't contain this class, as this isn't a page wide component, and can be embedded inside other apps.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/eletronicos/smartphones?map=c%2Cc%2CspecificationFilter_20&rest=Android%207.1).

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
