### PR TITLE
Hide breadcrumb for mobile viewport

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,8 @@
   "env": {
     "browser": true,
     "node": true,
-    "mocha": true
+    "mocha": true,
+    "jest": true
   },
   "globals": {
     "__DEV__": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.4] - 2018-10-24
 ### Fixed
 - hide breadcrumb for mobile viewport.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- hide breadcrumb for mobile viewport.
 
 ## [0.2.3] - 2018-09-14
 ### Removed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "breadcrumb",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "title": "VTEX Breadcrumb",
   "description": "Breadcrumb Component",
   "defaultLocale": "pt-BR",

--- a/react/Breadcrumb.js
+++ b/react/Breadcrumb.js
@@ -37,7 +37,7 @@ class Breadcrumb extends Component {
 
     const categoriesList = this.getCategories(categories)
     return (
-      <div className="vtex-breadcrumb pb4 pt4 gray">
+      <div className="vtex-breadcrumb dn dib-ns pb4 pt4 gray">
         <Link className={LINK_CLASS_NAME} page="store">
           <HomeIcon />
         </Link>

--- a/react/Breadcrumb.js
+++ b/react/Breadcrumb.js
@@ -37,7 +37,7 @@ class Breadcrumb extends Component {
 
     const categoriesList = this.getCategories(categories)
     return (
-      <div className="vtex-breadcrumb dn dib-ns pb4 pt4 gray">
+      <div className="vtex-breadcrumb dn db-ns pb4 pt4 gray">
         <Link className={LINK_CLASS_NAME} page="store">
           <HomeIcon />
         </Link>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Hide the breadcrumb for mobile viewport.

#### What problem is this solving?
The breadcrumb should not be rendered when in mobile viewport.

#### Screenshots or example usage

<a href="https://breadcrumb--storecomponents.myvtex.com">Click here to access the workspace</a>

![captura de tela de 2018-09-21 16-52-14](https://user-images.githubusercontent.com/9275109/45903049-cae15100-bdbe-11e8-8229-4ef118193bd5.png)
![captura de tela de 2018-09-21 16-52-29](https://user-images.githubusercontent.com/9275109/45903050-cae15100-bdbe-11e8-8fa1-6fa7c4be9133.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
