### PR TITLE
Fix/breadcrumb term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix term when it has an accented letter.
 
 ## [0.2.3] - 2018-09-14
 ### Removed

--- a/react/Breadcrumb.js
+++ b/react/Breadcrumb.js
@@ -58,7 +58,7 @@ class Breadcrumb extends Component {
               <ArrowIcon />
             </span>
             <span className="vtex-breadcrumbs__term ph2 near-black">
-              {term}
+              {decodeURIComponent(term)}
             </span>
           </Fragment>
         )}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix term of breadcrumb when you search a word with an accented letter
<!--- Describe your changes in detail. -->

#### What problem is this solving?
Uncoded term when you access a route of search and the term searched has an accented letter
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
[Accessing this workspace](https://decodeuribreadcrumb--storecomponents.myvtex.com/T%C3%AAnis/s?map=ft)
#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/8517023/46681475-ab6d6500-cbc1-11e8-8b2f-ce604ab5dd23.png)
![image](https://user-images.githubusercontent.com/8517023/46681657-19199100-cbc2-11e8-9dab-930a77a05c51.png)

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
