### PR TITLE
link spaces should be slugified with - character

### DIFF
--- a/react/Breadcrumb.tsx
+++ b/react/Breadcrumb.tsx
@@ -46,7 +46,12 @@ class Breadcrumb extends Component<Props> {
       let categoryStripped = category.replace(/^\//, '').replace(/\/$/, '')
       const categories = categoryStripped.split('/')
       const [categoryKey] = categories.reverse()
-      categoryStripped = unorm.nfd(categoryStripped).toLowerCase().replace(/[\u0300-\u036f]/g, '')
+      categoryStripped = unorm
+        .nfd(categoryStripped)
+        .toLowerCase()
+        .replace(/[\u0300-\u036f]/g, '')
+        .trim()
+        .replace(/[-\s]+/g, '-')
       categoryStripped += categories.length === 1 ? '/d' : ''
       return {
         name: categoryKey.toLowerCase(),


### PR DESCRIPTION
#### What is the purpose of this pull request?
This is a forward port of the fix released in branch 0.x
This PR fixes the link with spaces. Link with spaces should be slugified, i.e. spaces should become `-`

#### What problem is this solving?

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
