### PR TITLE
Make Breadcrumb receive categories with shape {name, link} instead of link strings only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Make `Breadcrumb` receive categories with shape `{name, link}` instead of link strings only.
+
 ### Added
 
 - Add tests.

--- a/react/Breadcrumb.tsx
+++ b/react/Breadcrumb.tsx
@@ -1,50 +1,32 @@
-import PropTypes from 'prop-types'
-import React, { Component, Fragment, ReactNode } from 'react'
+import React, { Fragment, useMemo } from 'react'
 import { Link } from 'vtex.render-runtime'
 import unorm from 'unorm'
 import { IconHome, IconCaret } from 'vtex.store-icons'
 
-import breadcrumb from './breadcrumb.css'
+import styles from './breadcrumb.css'
 
-const LINK_CLASS_NAME = `${breadcrumb.link} dib pv1 link ph2 c-muted-2 hover-c-link`
+const LINK_CLASS_NAME = `${styles.link} dib pv1 link ph2 c-muted-2 hover-c-link`
 
-interface DefaultProps {
-  categories: Array<string>
-}
-  
-interface Props extends DefaultProps {
-  term?: string
-}
-
-type Category = {
+interface Category {
   name: string
-  value: string
+  link: string
+}
+interface Props {
+  term?: string
+  categories: Array<Category>
 }
 
 /**
  * Breadcrumb Component.
  */
-class Breadcrumb extends Component<Props> {
-  public static readonly defaultProps = {
-    categories: [],
-  }
-
-  public static readonly propTypes = {
-    /** Search term or product slug. */
-    term: PropTypes.string,
-    /** Product's categories. */
-    categories: PropTypes.arrayOf(PropTypes.string),
-  }
-
-  private get categoriesList(): Array<Category> {
-    const { categories } = this.props
+const Breadcrumb = ({ term, categories }: Props) => {
+  const categoriesList = useMemo((): Array<Category> => {
     const categoriesSorted = categories
       .slice()
-      .sort((a, b) => a.length - b.length)
+      .sort((a, b) => a.link.length - b.link.length)
     return categoriesSorted.map(category => {
-      let categoryStripped = category.replace(/^\//, '').replace(/\/$/, '')
+      let categoryStripped = category.link.replace(/^\//, '').replace(/\/$/, '')
       const currentCategories = categoryStripped.split('/')
-      const [categoryKey] = currentCategories.reverse()
       categoryStripped = unorm
         .nfd(categoryStripped)
         .toLowerCase()
@@ -53,46 +35,40 @@ class Breadcrumb extends Component<Props> {
         .replace(/[-\s]+/g, '-')
       categoryStripped += currentCategories.length === 1 ? '/d' : ''
       return {
-        name: categoryKey.toLowerCase(),
-        value: categoryStripped,
+        name: category.name,
+        link: categoryStripped,
       }
     })
-  }
+  }, [categories])
 
-  public render(): ReactNode {
-    const { term, categories } = this.props
+  return !categories.length ? null : (
+    <div className={`${styles.container} dn db-ns pv3`}>
+      <Link className={`${LINK_CLASS_NAME} v-mid`} page="store.home">
+        <IconHome size={26} />
+      </Link>
+      {categoriesList.map(({ name, link }, i) => (
+        <span key={`category-${i}`} className={`${styles.arrow} ph2 c-muted-2`}>
+          <IconCaret orientation="right" size={8} />
+          <Link className={LINK_CLASS_NAME} to={`/${link}`}>
+            {name}
+          </Link>
+        </span>
+      ))}
 
-    if (!categories.length) {
-      return null
-    }
-
-    return (
-      <div className={`${breadcrumb.container} dn db-ns pv3`}>
-        <Link className={`${LINK_CLASS_NAME} v-mid`} page="store.home">
-          <IconHome size={26}/>
-        </Link>
-        {this.categoriesList.map(({ name, value }, i) => (
-          <span key={`category-${i}`} className={`${breadcrumb.arrow} ph2 c-muted-2`}>
-            <IconCaret orientation="right" size={8}/>
-            <Link className={LINK_CLASS_NAME} to={`/${value}`}>
-              {name}
-            </Link>
+      {term && (
+        <Fragment>
+          <span className={`${styles.arrow} ph2 c-muted-2`}>
+            <IconCaret orientation="right" size={8} />
           </span>
-        ))}
+          <span className={`${styles.term} ph2 c-on-base`}>{term}</span>
+        </Fragment>
+      )}
+    </div>
+  )
+}
 
-        {term && (
-          <Fragment>
-            <span className={`${breadcrumb.arrow} ph2 c-muted-2`}>
-              <IconCaret orientation="right" size={8}/>
-            </span>
-            <span className={`${breadcrumb.term} ph2 c-on-base`}>
-              {term}
-            </span>
-          </Fragment>
-        )}
-      </div>
-    )
-  }
+Breadcrumb.defaultProps = {
+  categories: [],
 }
 
 export default Breadcrumb

--- a/react/__tests__/BreadCrumb.test.js
+++ b/react/__tests__/BreadCrumb.test.js
@@ -7,7 +7,16 @@ import Breadcrumb from '../Breadcrumb'
 describe('<BreadCrumb /> component', () => {
   const renderComponent = customProps => {
     const props = {
-      categories: ['/Eletrônicos/Smartphones/', '/Eletrônicos/'],
+      categories: [
+        {
+          link: '/Eletrônicos/',
+          name: 'Eletrônicos',
+        },
+        {
+          link: '/Eletrônicos/Smartphones/',
+          name: 'Smartphones :)',
+        },
+      ],
       ...customProps,
     }
     return render(<Breadcrumb {...props} />)

--- a/react/__tests__/__snapshots__/BreadCrumb.test.js.snap
+++ b/react/__tests__/__snapshots__/BreadCrumb.test.js.snap
@@ -26,7 +26,7 @@ exports[`<BreadCrumb /> component should match the snapshot 1`] = `
       <a
         class="link"
       >
-        eletrônicos
+        Eletrônicos
       </a>
     </span>
     <span
@@ -41,7 +41,7 @@ exports[`<BreadCrumb /> component should match the snapshot 1`] = `
       <a
         class="link"
       >
-        smartphones
+        Smartphones :)
       </a>
     </span>
     <span


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
The `Breadcrumbs` names were incorrect.

#### How should this be manually tested?
Linked @ [workspace](https://mpsbread--storecomponents.myvtex.com/)


#### Types of changes
* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
