### PR TITLE
Create product-breadcrumb block to apply product context

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ This app has an interface that describes what rules must be implemented by a blo
 {
   "breadcrumb": {
     "component": "Breadcrumb"
+  },
+  "product-breadcrumb": {
+    "component": "BreadcrumbProduct"
   }
 }
 ```

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,7 @@
     "postreleasy": "vtex publish --verbose"
   },
   "dependencies": {
-    "vtex.store-icons": "0.x"
+    "vtex.store-icons": "0.x",
+    "vtex.product-context": "0.x"
   }
 }

--- a/react/BreadcrumbProduct.tsx
+++ b/react/BreadcrumbProduct.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react'
+import { ProductContext } from 'vtex.product-context'
+import { path, isEmpty } from 'ramda'
+
+import Breadcrumb from './Breadcrumb';
+
+interface Props {
+  term?: string | undefined
+  categories: Array<string> | undefined
+}
+
+const BreadcrumbProduct = (props: Props) => {
+  const valuesFromContext = React.useContext(ProductContext)
+
+  const defProps: Props = !valuesFromContext || isEmpty(valuesFromContext)
+    ? props
+    : { term: path(['product', 'productName'], valuesFromContext), categories: path(['categories'], valuesFromContext) }
+
+  const { term, categories } = defProps
+
+  return (
+    <Breadcrumb 
+      term={term} 
+      categories={categories} 
+    />
+  )
+}
+
+BreadcrumbProduct.defaultProps = {
+  categories: [],
+}
+
+export default BreadcrumbProduct

--- a/react/package.json
+++ b/react/package.json
@@ -21,6 +21,7 @@
     "unorm": "^1.4.1"
   },
   "devDependencies": {
+    "@types/ramda": "^0.26.8",
     "@types/react": "^16.4.18",
     "@types/react-dom": "^16.0.9",
     "@types/unorm": "^1.3.27",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -153,6 +153,11 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.0.tgz#4c48fed958d6dcf9487195a0ef6456d5f6e0163a"
   integrity sha512-eItQyV43bj4rR3JPV0Skpl1SncRCdziTEK9/v8VwXmV6d/qOUO8/EuWeHBbCZcsfSHfzI5UyMJLCSXtxxznyZg==
 
+"@types/ramda@^0.26.8":
+  version "0.26.8"
+  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.26.8.tgz#e002612cca52e52f9176d577f4d6229c8c72a10a"
+  integrity sha512-PSMkNNhB900U2xcyndlkVjJeCXpVtf1yod0Kdq/ArsLDIE0tW8pLBChmQeJs4o4dfp3AEP+AGm6zIseZPU4ndA==
+
 "@types/react-dom@^16.0.9":
   version "16.8.2"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.2.tgz#9bd7d33f908b243ff0692846ef36c81d4941ad12"

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -2,7 +2,7 @@
   "breadcrumb": {
     "component": "Breadcrumb"
   },
-  "product-breadcrumb": {
+  "breadcrumb.product": {
     "component": "BreadcrumbProduct"
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,5 +1,8 @@
 {
   "breadcrumb": {
     "component": "Breadcrumb"
+  },
+  "product-breadcrumb": {
+    "component": "BreadcrumbProduct"
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Be able to use breadcrumb on the new product details.

#### What problem is this solving?
The breadcrumb is now unavailable to receive its parameters in product details page, so we have to parse it from product context.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Requires change to documentation, which has been updated accordingly.
