### PR TITLE
Changes props interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Category tree prop for displaying breadcrumb along with correct link
 
 ## [1.3.6] - 2019-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.4.0] - 2019-05-07
 ### Added
 - Category tree prop for displaying breadcrumb along with correct link
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "breadcrumb",
-  "version": "1.3.6",
+  "version": "1.4.0",
   "title": "VTEX Breadcrumb",
   "description": "Breadcrumb Component",
   "defaultLocale": "pt-BR",

--- a/react/Breadcrumb.tsx
+++ b/react/Breadcrumb.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment, useMemo } from 'react'
-import { Link } from 'vtex.render-runtime'
 import unorm from 'unorm'
-import { IconHome, IconCaret } from 'vtex.store-icons'
+import { Link } from 'vtex.render-runtime'
+import { IconCaret, IconHome } from 'vtex.store-icons'
 
 import styles from './breadcrumb.css'
 
@@ -9,71 +9,77 @@ const LINK_CLASS_NAME = `${styles.link} dib pv1 link ph2 c-muted-2 hover-c-link`
 
 interface Category {
   name: string
-  link: string
+  href: string
 }
+
 interface Props {
   term?: string
   /** Shape [ '/Department' ,'/Department/Category'] */
-  categories: Array<string>
+  categories: string[]
+  categoryTree: Category[]
 }
 
-const makeLink = (string: string) =>
+const makeLink = (str: string) =>
   unorm
-    .nfd(string)
+    .nfd(str)
     .toLowerCase()
     .replace(/[\u0300-\u036f]/g, '')
     .trim()
     .replace(/[-\s]+/g, '-')
 
+const getCategoriesList = (categories: string[]) : Category[] => {
+  const categoriesSorted = categories
+    .slice()
+    .sort((a, b) => a.length - b.length)
+  return categoriesSorted.map(category => {
+    const categoryStripped = category
+      .replace(/^\//, '')
+      .replace(/\/$/, '')
+    const currentCategories = categoryStripped.split('/')
+    const [categoryKey] = currentCategories.reverse()
+    const linkCompletion = currentCategories.length === 1 ? '/d' : ''
+    const href = `/${makeLink(categoryStripped)}${linkCompletion}`
+    return {
+      href,
+      name: categoryKey,
+    }
+  })
+}
+
 /**
  * Breadcrumb Component.
  */
-const Breadcrumb = ({ term, categories }: Props) => {
+const Breadcrumb = ({ term, categories, categoryTree }: Props) => {
+  const categoriesList = categoryTree 
+    ? categoryTree
+    : useMemo(() => getCategoriesList(categories), [categories])
 
-  const getCategoriesList = (categories:Array<string>) : Array<Category> => {
-    const categoriesSorted = categories
-      .slice()
-      .sort((a, b) => a.length - b.length)
-    return categoriesSorted.map(category => {
-      const categoryStripped = category
-        .replace(/^\//, '')
-        .replace(/\/$/, '')
-      const currentCategories = categoryStripped.split('/')
-      const [categoryKey] = currentCategories.reverse()
-      const linkCompletion = currentCategories.length === 1 ? '/d' : ''
-      const link = makeLink(categoryStripped) + linkCompletion
-      return {
-        name: categoryKey,
-        link: link,
-      }
-    })
-  }
-  const categoriesList = useMemo(() => getCategoriesList(categories), [categories])
-
-  return !categories.length ? null : (
-    <div className={`${styles.container} dn db-ns pv3`}>
-      <Link className={`${LINK_CLASS_NAME} v-mid`} page="store.home">
-        <IconHome size={26} />
-      </Link>
-      {categoriesList.map(({ name, link }, i) => (
-        <span key={`category-${i}`} className={`${styles.arrow} ph2 c-muted-2`}>
-          <IconCaret orientation="right" size={8} />
-          <Link className={LINK_CLASS_NAME} to={`/${link}`}>
-            {name}
-          </Link>
-        </span>
-      ))}
-
-      {term && (
-        <Fragment>
-          <span className={`${styles.arrow} ph2 c-muted-2`}>
+  return !categoriesList.length
+    ? null 
+    : (
+      <div className={`${styles.container} dn db-ns pv3`}>
+        <Link className={`${LINK_CLASS_NAME} v-mid`} page="store.home">
+          <IconHome size={26} />
+        </Link>
+        {categoriesList.map(({ name, href }, i) => (
+          <span key={`category-${i}`} className={`${styles.arrow} ph2 c-muted-2`}>
             <IconCaret orientation="right" size={8} />
+            <Link className={LINK_CLASS_NAME} to={href}>
+              {name}
+            </Link>
           </span>
-          <span className={`${styles.term} ph2 c-on-base`}>{term}</span>
-        </Fragment>
-      )}
-    </div>
-  )
+        ))}
+
+        {term && (
+          <Fragment>
+            <span className={`${styles.arrow} ph2 c-muted-2`}>
+              <IconCaret orientation="right" size={8} />
+            </span>
+            <span className={`${styles.term} ph2 c-on-base`}>{term}</span>
+          </Fragment>
+        )}
+      </div>
+    )
 }
 
 Breadcrumb.defaultProps = {

--- a/react/Breadcrumb.tsx
+++ b/react/Breadcrumb.tsx
@@ -50,9 +50,10 @@ const getCategoriesList = (categories: string[]) : Category[] => {
  * Breadcrumb Component.
  */
 const Breadcrumb = ({ term, categories, categoryTree }: Props) => {
-  const categoriesList = categoryTree 
-    ? categoryTree
-    : useMemo(() => getCategoriesList(categories), [categories])
+  const categoriesList = useMemo(
+    () => categoryTree || getCategoriesList(categories), 
+    [categories, categoryTree]
+  )
 
   return !categoriesList.length
     ? null 

--- a/react/Breadcrumb.tsx
+++ b/react/Breadcrumb.tsx
@@ -49,7 +49,7 @@ const getCategoriesList = (categories: string[]) : Category[] => {
 /**
  * Breadcrumb Component.
  */
-const Breadcrumb = ({ term, categories, categoryTree }: Props) => {
+const Breadcrumb: React.FunctionComponent<Props> = ({ term, categories, categoryTree }) => {
   const categoriesList = useMemo(
     () => categoryTree || getCategoriesList(categories), 
     [categories, categoryTree]


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make this component to work with translated categories

#### What problem is this solving?
Currently, there is a huge problem when trying to use this component in an internationalized store. The problem comes form the fact that this component generates itself the links to the categories/departments instead of only rendering what it got from the props

For example, let's suppose we are in the product page `/galaxy/p`. This product is currently located in the `/electronics/smartphones` subcategory. Currently this component will receive in the `categories` variable the following array:

```
['electronics', 'smartphones']
```

And generate, with this information only, links to the corresponding categories/subcategories, a.k.a. `/electronics/d` and `/electronics/smartphones` respectively. The problem arises when we try to translate this page to French. In French, the incoming prop would be :

```
['electroniques', 'portables']
```

thus, generating links to `/electroniques/d` and `/electroniques/portables`, which do not exist in our route map. 

To address the aforementioned problem I suggest using a new prop called `categoryTree`. This prop would receive, instead of an string array, an object with the following format 

```
interface CategoryTree {
name: string
href: string
}
```

where the property `name` is the translated name, and `href` is the final link to the department/category.

This PR implements this idea while not creating a breaking change since this PR keeps the old behavior of the `categories` prop

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
