### PR TITLE
Added `showOnMobile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `showOnMobile` on `SearchResult`
+
 ## [1.5.4] - 2019-08-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Through the Storefront, you can change the behavior and interface of the breadcr
 | ------------ | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `term`       | `String`        | Search term that is used to get to that specific page on the website or product slug that is the unique identification stored on the database |
 | `categories` | `Array(String)` | List of categories which the product belongs to                                                                                               |
+| `showOnMobile`        | `Boolean`       | if breadcrumbs should be displayed on mobile         | `false`              |
 
 :loudspeaker: **Extra information:** The product's categories should appear as an array in one of this two formats:
 

--- a/react/Breadcrumb.tsx
+++ b/react/Breadcrumb.tsx
@@ -20,6 +20,7 @@ export interface Props {
   categories: string[]
   categoryTree?: NavigationItem[]
   breadcrumb?: NavigationItem[]
+  showOnMobile?: Boolean
 }
 
 const makeLink = (str: string) =>
@@ -61,6 +62,7 @@ const withProductContextWrapper = (
       categories={categories}
       categoryTree={categoryTree}
       breadcrumb={props.breadcrumb}
+      showOnMobile={props.showOnMobile}
     />
   )
 }
@@ -73,14 +75,17 @@ const Breadcrumb: React.FC<Props> = ({
   categories,
   categoryTree,
   breadcrumb,
+  showOnMobile,
 }) => {
   const navigationList = useMemo(
     () => breadcrumb || categoryTree || getCategoriesList(categories),
     [breadcrumb, categories, categoryTree]
   )
 
+  const breadcrumbStyle = showOnMobile ? '' : 'dn db-ns'
+
   return !navigationList.length ? null : (
-    <div className={`${styles.container} pv3`}>
+    <div data-testid="breadcrumb" className={`${styles.container} ${breadcrumbStyle} pv3`}>
       <Link className={`${LINK_CLASS_NAME} v-mid`} page="store.home">
         <IconHome size={26} />
       </Link>

--- a/react/__tests__/BreadCrumb.test.tsx
+++ b/react/__tests__/BreadCrumb.test.tsx
@@ -34,4 +34,16 @@ describe('<BreadCrumb /> component', () => {
 
     expect(queryByText('term')).toBeNull()
   })
+
+  it('should have dn db-ns if showOnMobile is false', () => {
+    const { getByTestId } = renderComponent({showOnMobile: false,})
+    const container = getByTestId('breadcrumb')
+    expect(container.className).toContain('dn db-ns')
+  })
+
+  it('should not have dn if showOnMobile is true', () => {
+    const { getByTestId } = renderComponent({showOnMobile: true,})
+    const container = getByTestId('breadcrumb')
+    expect(container.className).not.toContain('dn')
+  })
 })

--- a/react/__tests__/__snapshots__/BreadCrumb.test.tsx.snap
+++ b/react/__tests__/__snapshots__/BreadCrumb.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`<BreadCrumb /> component should match the snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="container pv3"
+    class="container dn db-ns pv3"
+    data-testid="breadcrumb"
   >
     <a
       class="link"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Added a prop `showOnMobile` that makes it possible to have breadcrumbs on mobile

#### How should this be manually tested?

[workspace](https://iaronaraujo--storecomponents.myvtex.com/apparel---accessories/clothing/)
test on mobile

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/62630428-45e32580-b905-11e9-9fc6-5daf7318fd01.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Requires change to documentation, which has been updated accordingly.
