### PR TITLE
more contextual blocks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `breadcrumb.product` and `breadcrumb.search` blocks.
 
 ## [1.6.0] - 2019-08-07
 

--- a/manifest.json
+++ b/manifest.json
@@ -11,15 +11,14 @@
   },
   "mustUpdateAt": "2019-04-02",
   "categories": [],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "scripts": {
     "postreleasy": "vtex publish --verbose"
   },
   "dependencies": {
     "vtex.store-icons": "0.x",
-    "vtex.product-context": "0.x"
+    "vtex.product-context": "0.x",
+    "vtex.search-page-context": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/ProductBreadcumb.tsx
+++ b/react/ProductBreadcumb.tsx
@@ -1,0 +1,2 @@
+import ProductBreadcrumb from './components/ProductBreadcrumb'
+export default ProductBreadcrumb

--- a/react/SearchBreadcrumb.tsx
+++ b/react/SearchBreadcrumb.tsx
@@ -1,0 +1,2 @@
+import SearchBreadcrumb from './components/SearchBreadcrumb'
+export default SearchBreadcrumb

--- a/react/__tests__/BreadCrumb.test.tsx
+++ b/react/__tests__/BreadCrumb.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { render } from '@vtex/test-tools/react'
 
-import Breadcrumb, { Props } from '../Breadcrumb'
+import Breadcrumb from '../Breadcrumb'
+import { Props } from '../components/BaseBreadcrumb'
 
 describe('<BreadCrumb /> component', () => {
   const defaultCategories = ['/Eletrônicos/Smartphones/', '/Eletrônicos/']
@@ -36,13 +37,13 @@ describe('<BreadCrumb /> component', () => {
   })
 
   it('should have dn db-ns if showOnMobile is false', () => {
-    const { getByTestId } = renderComponent({showOnMobile: false,})
+    const { getByTestId } = renderComponent({ showOnMobile: false })
     const container = getByTestId('breadcrumb')
     expect(container.className).toContain('dn db-ns')
   })
 
   it('should not have dn if showOnMobile is true', () => {
-    const { getByTestId } = renderComponent({showOnMobile: true,})
+    const { getByTestId } = renderComponent({ showOnMobile: true })
     const container = getByTestId('breadcrumb')
     expect(container.className).not.toContain('dn')
   })

--- a/react/components/BaseBreadcrumb.tsx
+++ b/react/components/BaseBreadcrumb.tsx
@@ -64,7 +64,10 @@ const Breadcrumb: React.FC<Props> = ({
   const breadcrumbStyle = showOnMobile ? '' : 'dn db-ns'
 
   return !navigationList.length ? null : (
-    <div className={`${styles.container} ${breadcrumbStyle} pv3`}>
+    <div
+      data-testid="breadcrumb"
+      className={`${styles.container} ${breadcrumbStyle} pv3`}
+    >
       <Link className={`${LINK_CLASS_NAME} v-mid`} page="store.home">
         <IconHome size={26} />
       </Link>

--- a/react/components/BaseBreadcrumb.tsx
+++ b/react/components/BaseBreadcrumb.tsx
@@ -1,0 +1,99 @@
+import React, { Fragment, useMemo } from 'react'
+import unorm from 'unorm'
+import { Link } from 'vtex.render-runtime'
+import { IconCaret, IconHome } from 'vtex.store-icons'
+
+import styles from '../breadcrumb.css'
+
+const LINK_CLASS_NAME = `${styles.link} dib pv1 link ph2 c-muted-2 hover-c-link`
+
+export interface NavigationItem {
+  name: string
+  href: string
+}
+
+export interface Props {
+  term?: string
+  /** Shape [ '/Department' ,'/Department/Category'] */
+  categories: string[]
+  categoryTree?: NavigationItem[]
+  breadcrumb?: NavigationItem[]
+  showOnMobile?: boolean
+}
+
+const makeLink = (str: string) =>
+  unorm
+    .nfd(str)
+    .toLowerCase()
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .replace(/[-\s]+/g, '-')
+
+const getCategoriesList = (categories: string[]): NavigationItem[] => {
+  const categoriesSorted = categories
+    .slice()
+    .sort((a, b) => a.length - b.length)
+  return categoriesSorted.map(category => {
+    const categoryStripped = category.replace(/^\//, '').replace(/\/$/, '')
+    const currentCategories = categoryStripped.split('/')
+    const [categoryKey] = currentCategories.reverse()
+    const linkCompletion = currentCategories.length === 1 ? '/d' : ''
+    const href = `/${makeLink(categoryStripped)}${linkCompletion}`
+    return {
+      href,
+      name: categoryKey,
+    }
+  })
+}
+
+/**
+ * Breadcrumb Component.
+ */
+const Breadcrumb: React.FC<Props> = ({
+  term,
+  categories,
+  categoryTree,
+  breadcrumb,
+  showOnMobile,
+}) => {
+  const navigationList = useMemo(
+    () => breadcrumb || categoryTree || getCategoriesList(categories),
+    [breadcrumb, categories, categoryTree]
+  )
+
+  const breadcrumbStyle = showOnMobile ? '' : 'dn db-ns'
+
+  return !navigationList.length ? null : (
+    <div className={`${styles.container} ${breadcrumbStyle} pv3`}>
+      <Link className={`${LINK_CLASS_NAME} v-mid`} page="store.home">
+        <IconHome size={26} />
+      </Link>
+      {navigationList.map(({ name, href }, i) => (
+        <span
+          key={`navigation-item-${i}`}
+          className={`${styles.arrow} ph2 c-muted-2`}
+        >
+          <IconCaret orientation="right" size={8} />
+          <Link className={LINK_CLASS_NAME} to={href}>
+            {name}
+          </Link>
+        </span>
+      ))}
+
+      {term && (
+        <Fragment>
+          <span className={`${styles.arrow} ph2 c-muted-2`}>
+            <IconCaret orientation="right" size={8} />
+          </span>
+          <span className={`${styles.term} ph2 c-on-base`}>{term}</span>
+        </Fragment>
+      )}
+    </div>
+  )
+}
+
+Breadcrumb.defaultProps = {
+  categories: [],
+}
+
+export default Breadcrumb

--- a/react/components/ProductBreadcrumb/README.md
+++ b/react/components/ProductBreadcrumb/README.md
@@ -1,0 +1,14 @@
+# VTEX Product Breadcrumb
+
+This block (`breadcrumb.product`) is meant to be used inside your product page. It uses the Product Context and only fetches data from there.
+
+It has the same props as the original `breadcrumb` block.
+
+## Example usage
+
+```
+js
+"store.product": {
+  "children": ["breadcrumb.product"]
+}
+```

--- a/react/components/ProductBreadcrumb/index.tsx
+++ b/react/components/ProductBreadcrumb/index.tsx
@@ -1,15 +1,15 @@
 import React, { useContext } from 'react'
 import { ProductContext } from 'vtex.product-context'
 import { path, pathOr } from 'ramda'
-import BaseBreadcrumb, { Props } from './components/BaseBreadcrumb'
+import BaseBreadcrumb, { Props, NavigationItem } from '../BaseBreadcrumb'
 
 const withProductContextWrapper = (
   Component: React.ComponentType<Props>
 ): React.FC<Props> => props => {
   const { product } = useContext(ProductContext) || { product: null }
-  const term = props.term || path(['productName'], product)
-  const categoryTree = props.categoryTree || path(['categoryTree'], product)
-  const categories = props.categories || pathOr([], ['categories'], product)
+  const term = path<string>(['productName'], product)
+  const categoryTree = path<NavigationItem[]>(['categoryTree'], product)
+  const categories = pathOr([], ['categories'], product)
 
   return (
     <Component

--- a/react/components/SearchBreadcrumb/README.md
+++ b/react/components/SearchBreadcrumb/README.md
@@ -1,0 +1,14 @@
+# VTEX Search Breadcrumb
+
+This block (`breadcrumb.search`) is meant to be used inside your search page. It uses the Search Page Context and only fetches data from there.
+
+It has the same props as the original `breadcrumb` block.
+
+## Example usage
+
+```
+js
+"search-result-layout.desktop": {
+  "children": ["breadcrumb.search"]
+}
+```

--- a/react/components/SearchBreadcrumb/index.tsx
+++ b/react/components/SearchBreadcrumb/index.tsx
@@ -1,0 +1,26 @@
+import React, { FC } from 'react'
+import { pathOr } from 'ramda'
+import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
+import BaseBreadcrumb, { NavigationItem } from '../BaseBreadcrumb'
+
+interface Props {
+  showOnMobile?: boolean
+}
+
+const SearchBreadcrumb: FC<Props> = ({ showOnMobile }) => {
+  const { searchQuery } = useSearchPage()
+  const breadcrumb = pathOr<NavigationItem[]>(
+    [],
+    ['data', 'productSearch', 'breadcrumb'],
+    searchQuery
+  )
+  return (
+    <BaseBreadcrumb
+      breadcrumb={breadcrumb}
+      showOnMobile={showOnMobile}
+      categories={[]} //unused prop, its OK
+    />
+  )
+}
+
+export default SearchBreadcrumb

--- a/react/typings/vtex.search-page-context/SearchPageContext.d.ts
+++ b/react/typings/vtex.search-page-context/SearchPageContext.d.ts
@@ -1,0 +1,3 @@
+declare module 'vtex.search-page-context/SearchPageContext' {
+  export const useSearchPage: () => any
+}

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,5 +1,11 @@
 {
   "breadcrumb": {
     "component": "Breadcrumb"
+  },
+  "breadcrumb.product": {
+    "component": "ProductBreadcrumb"
+  },
+  "breadcrumb.search": {
+    "component": "SearchBreadcrumb"
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Create new breadcrumb.product and breadcrumb.search blocks.

#### What problem is this solving?

As we have more contexts, the breadcrumb was getting confusing from where it gets its props. Create more contextual blocks for this.

#### How should this be manually tested?

https://fidelis--storecomponents.myvtex.com/apparel---accessories/clothing/

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.