### PR TITLE
use waitToPrefetch prop on Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use `waitForPrefetch` prop when renderings `<Link />`.
 
 ## [1.8.4] - 2019-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Use `waitForPrefetch` prop when renderings `<Link />`.
+- Use `waitForPrefetch` prop when rendering `<Link />`.
 
 ## [1.8.4] - 2019-12-16
 

--- a/react/components/BaseBreadcrumb.tsx
+++ b/react/components/BaseBreadcrumb.tsx
@@ -105,6 +105,7 @@ const Breadcrumb: React.FC<Props> = ({
               (i + 1).toString()
             )} ${linkBaseClasses}`}
             to={href}
+            // See https://github.com/vtex-apps/breadcrumb/pull/66 for the reasoning behind this
             waitToPrefetch={1200}
           >
             {name}

--- a/react/components/BaseBreadcrumb.tsx
+++ b/react/components/BaseBreadcrumb.tsx
@@ -105,6 +105,7 @@ const Breadcrumb: React.FC<Props> = ({
               (i + 1).toString()
             )} ${linkBaseClasses}`}
             to={href}
+            waitToPrefetch={1200}
           >
             {name}
           </Link>

--- a/react/package.json
+++ b/react/package.json
@@ -27,7 +27,7 @@
     "prettier": "^1.17.1",
     "react-apollo": "^2.1.3",
     "react-dom": "^16.3.1",
-    "typescript": "3.5.2",
+    "typescript": "3.8.3",
     "vtex.css-handles": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.css-handles@0.4.1/public/@types/vtex.css-handles",
     "vtex.search-page-context": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.search-page-context@0.0.1/public/_types/react",
     "vtex.store-icons": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.store-icons@0.13.4/public/@types/vtex.store-icons",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5057,10 +5057,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 typescript@^3.3.3333:
   version "3.4.5"


### PR DESCRIPTION
Make use of new waitToPrefetch prop on <Link> component
What problem is this solving?
When implementing prefetch, there is a problem with the breadcrumb that cannot be fixed properly.
When the product is loading, the product context is empty and it for a brief moment renders the breadcrumb with the fallback data, based on the old category tree data (deprecated).
Then the product loads and we render the breadcrumb correctly.
But before, we would start the prefetch with the fallback data and do not prefetch the updated data, since we do the prefetch logic on mount and we should do it only once to avoid a series of problems.
The only way to fix this without breaking the breadcrumb for users with the flexible PDP and not flexible PDP is to use this waitToPrefetch prop on link, making the Link component wait 1200ms before prefetching whatever href it has at that moment.