### PR TITLE
Use facets breadcrumb as fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Accept `facets` breadcrumb as fallback.
+
 ## [1.8.5] - 2020-04-24
 ### Changed
 - Use `waitForPrefetch` prop when rendering `<Link />`.

--- a/react/components/SearchBreadcrumb/index.tsx
+++ b/react/components/SearchBreadcrumb/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react'
-import { pathOr } from 'ramda'
+import { path } from 'ramda'
 import { useSearchPage } from 'vtex.search-page-context/SearchPageContext'
 import BaseBreadcrumb, { NavigationItem } from '../BaseBreadcrumb'
 
@@ -15,11 +15,14 @@ const SearchBreadcrumb: FC<Props> = ({
   caretIconSize,
 }) => {
   const { searchQuery } = useSearchPage()
-  const breadcrumb = pathOr<NavigationItem[]>(
-    [],
-    ['data', 'productSearch', 'breadcrumb'],
-    searchQuery
-  )
+  const breadcrumb =
+    path<NavigationItem[]>(
+      ['data', 'productSearch', 'breadcrumb'],
+      searchQuery
+    ) ||
+    path<NavigationItem[]>(['data', 'facets', 'breadcrumb'], searchQuery) ||
+    []
+
   return (
     <BaseBreadcrumb
       breadcrumb={breadcrumb}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Since breadcrumb is a "list" of selected facets, the `vtex.search-resolver@1.x` performs better if this info comes from the `facets` query instead of the `productSearch` query.

This PR adds the `facets` breadcrumb as fallback. 

#### How should this be manually tested?
[Workpace](https://hiago--storecomponents.myvtex.com/)

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
