### PR TITLE
Fix encoded names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Breadcrumb with encoded names.
+
 ## [1.9.1] - 2020-09-15
 ### Security
 - Update `mixin-deep` to `1.3.2`.

--- a/react/components/BaseBreadcrumb.tsx
+++ b/react/components/BaseBreadcrumb.tsx
@@ -91,28 +91,38 @@ const Breadcrumb: React.FC<Props> = ({
       >
         <IconHome size={homeIconSize} />
       </Link>
-      {navigationList.map(({ name, href }, i) => (
-        <span
-          key={`navigation-item-${i}`}
-          className={`${applyModifiers(
-            handles.arrow,
-            (i + 1).toString()
-          )} ph2 c-muted-2`}
-        >
-          <IconCaret orientation="right" size={caretIconSize} />
-          <Link
+      {navigationList.map(({ name, href }, i) => {
+        let decodedName = ''
+
+        try {
+          decodedName = decodeURIComponent(name)
+        } catch {
+          decodedName = name
+        }
+
+        return (
+          <span
+            key={`navigation-item-${i}`}
             className={`${applyModifiers(
-              handles.link,
+              handles.arrow,
               (i + 1).toString()
-            )} ${linkBaseClasses}`}
-            to={href}
-            // See https://github.com/vtex-apps/breadcrumb/pull/66 for the reasoning behind this
-            waitToPrefetch={1200}
+            )} ph2 c-muted-2`}
           >
-            {name}
-          </Link>
-        </span>
-      ))}
+            <IconCaret orientation="right" size={caretIconSize} />
+            <Link
+              className={`${applyModifiers(
+                handles.link,
+                (i + 1).toString()
+              )} ${linkBaseClasses}`}
+              to={href}
+              // See https://github.com/vtex-apps/breadcrumb/pull/66 for the reasoning behind this
+              waitToPrefetch={1200}
+            >
+              {decodedName}
+            </Link>
+          </span>
+        )
+      })}
 
       {term && (
         <Fragment>

--- a/react/package.json
+++ b/react/package.json
@@ -26,7 +26,7 @@
     "@vtex/tsconfig": "^0.4.4",
     "apollo-cache-inmemory": "^1.2.2",
     "graphql": "^14.6.0",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles",
     "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.4/public/@types/vtex.device-detector",
     "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.8.1/public/@types/vtex.product-context",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5927,12 +5927,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-typescript@^3.7.3:
+typescript@3.9.7, typescript@^3.7.3:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
#### What problem is this solving?

Breadcrumb can receive encoded names, so we need to decode them to display

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://encodeurl--biscoind.myvtex.com/3-48m%2fs?_q=3-48m/s&map=ft)

#### Screenshots or example usage:

Before:
![image](https://user-images.githubusercontent.com/20840671/107697347-e2704b80-6c91-11eb-85ea-e59f36b49924.png)

After:
![image](https://user-images.githubusercontent.com/20840671/107697461-02a00a80-6c92-11eb-8fc1-1e832f66c513.png)

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

https://github.com/vtex-apps/search-result/pull/490

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)