### PR TITLE
Added comma sanitization in BaseBreadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Breadcrumb with commas in the names
+
 ## [1.9.4] - 2021-07-16
 
 ### Fixed

--- a/react/components/BaseBreadcrumb.tsx
+++ b/react/components/BaseBreadcrumb.tsx
@@ -34,7 +34,7 @@ const makeLink = (str: string) =>
   unorm
     .nfd(str)
     .toLowerCase()
-    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[\u0300-\u036f\u002C]/g, '')
     .trim()
     .replace(/[-\s]+/g, '-')
 


### PR DESCRIPTION
#### What problem is this solving?

Commas are not replaced in the category breadcrumb and it's causing errors in google search console for out clients where the category contains a comma.

#### How to test it?

1. Create a category with a comma in the name
2. Add a product inside it
3. Go to that product's page and view source, search for vtex-breadcrumb-1-x-link--1 and find the href to the category (should be with a comma)
4. Link the change in this PR, the comma will disappear

#### Screenshots or example usage:

Before the fix:
![image](https://user-images.githubusercontent.com/71461884/174570563-3ada31a2-747f-4d71-91c0-dd102b72ef21.png)

After the fix:
![image](https://user-images.githubusercontent.com/71461884/174570366-ba6b969a-a5cb-4268-8ad0-7bc3f4b65075.png)

#### Describe alternatives you've considered, if any.

N/A