### PR TITLE
Fix/replace scharacter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Replace special characters as `"!@#$%ˆ&*()`
+
 ## [1.9.4] - 2021-07-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Replace special characters as `"!@#$%ˆ&*()`
+- Keeping quotes in the URL
 
 ## [1.9.4] - 2021-07-16
 

--- a/react/components/BaseBreadcrumb.tsx
+++ b/react/components/BaseBreadcrumb.tsx
@@ -35,7 +35,6 @@ const makeLink = (str: string) =>
     .nfd(str)
     .toLowerCase()
     .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[\u0021-\u002c\u0040]/g, '')
     .trim()
     .replace(/[-\s]+/g, '-')
 
@@ -48,8 +47,7 @@ const getCategoriesList = (categories: string[]): NavigationItem[] => {
     const categoryStripped = category.replace(/^\//, '').replace(/\/$/, '')
     const currentCategories = categoryStripped.split('/')
     const [categoryKey] = currentCategories.reverse()
-    const linkCompletion = currentCategories.length === 1 ? '/d' : ''
-    const href = `/${makeLink(categoryStripped)}${linkCompletion}`
+    const href = `/${makeLink(categoryStripped)}`
 
     return {
       href,
@@ -73,7 +71,7 @@ const Breadcrumb: React.FC<Props> = ({
   const handles = useCssHandles(CSS_HANDLES)
   const { isMobile } = useDevice()
   const navigationList = useMemo(
-    () => breadcrumb ?? categoryTree ?? getCategoriesList(categories),
+    () => breadcrumb ?? getCategoriesList(categories) ?? categoryTree,
     [breadcrumb, categories, categoryTree]
   )
 

--- a/react/components/BaseBreadcrumb.tsx
+++ b/react/components/BaseBreadcrumb.tsx
@@ -35,6 +35,7 @@ const makeLink = (str: string) =>
     .nfd(str)
     .toLowerCase()
     .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[\u0021-\u002c\u0040]/g, '')
     .trim()
     .replace(/[-\s]+/g, '-')
 


### PR DESCRIPTION


#### What problem is this solving?

Currently our system replaces special characters in the url. However, some urls index with the special characters and it actually breaks in the breadcrumb since it's replaced. 

#### How to test it?

https://whitebird.myvtex.com/box-12x10x8-23c-kraft-rsc-25500-light-weight/p

https://vysk--whitebird.myvtex.com/box-12x10x8-23c-kraft-rsc-25500-light-weight/p

You can click in the category `12-13" Corrugated Boxes` and you will se the difference between both workspace.

#### Related to / Depends on

I firstly opened this PR https://github.com/vtex-apps/breadcrumb/pull/94, but then realized it wouldn't solve the problem.


#### Describe alternatives you've considered, if any.

I know maybe it's not the best solution, but it covers some issues we have with some clients and it seems to be easier than changing the backend. I also change the fallback of `/d`.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://camo.githubusercontent.com/c12c94a1d7cbdd46eb1f8b9ff5bdfc06f758f19423fedf7cae73237c817c193f/68747470733a2f2f6d656469612e74656e6f722e636f6d2f6c506c715474704d4e5f3441414141432f6c6f6f6e612d6879756e6a696e2e676966)
