### PR TITLE
Add aria-label to resolve accessibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,8 @@
   "builders": {
     "store": "0.x",
     "react": "3.x",
-    "docs": "0.x"
+    "docs": "0.x",
+    "messages": "1.x"
   },
   "mustUpdateAt": "2019-04-02",
   "categories": [],

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,3 @@
+{
+  "store/breadcrumb.homeLink": "Home Link"
+}

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,0 +1,3 @@
+{
+  "store/breadcrumb.homeLink": "Enlace de Inicio"
+}

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,0 +1,3 @@
+{
+  "store/breadcrumb.homeLink": "Link de Início"
+}

--- a/react/components/BaseBreadcrumb.tsx
+++ b/react/components/BaseBreadcrumb.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment, useMemo } from 'react'
 import unorm from 'unorm'
+import { useIntl } from 'react-intl'
 import { Link } from 'vtex.render-runtime'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import { IconCaret, IconHome } from 'vtex.store-icons'
@@ -69,6 +70,7 @@ const Breadcrumb: React.FC<Props> = ({
   homeIconSize = 26,
   caretIconSize = 8,
 }) => {
+  const intl = useIntl()
   const handles = useCssHandles(CSS_HANDLES)
   const { isMobile } = useDevice()
   const navigationList = useMemo(
@@ -88,6 +90,9 @@ const Breadcrumb: React.FC<Props> = ({
       <Link
         className={`${handles.link} ${handles.homeLink} ${linkBaseClasses} v-mid`}
         page="store.home"
+        aria-label={intl.formatMessage({
+          id: 'store/breadcrumb.homeLink',
+        })}
       >
         <IconHome size={homeIconSize} />
       </Link>


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
- Adicionado a propriedade `aria-label` para melhorar a experiência e resolver os alertas de acessibilidade da regra que [links precisam ter um nome compreensível](https://dequeuniversity.com/rules/axe/4.7/link-name), apontados pelo Lighthouse.
- Adicionado o builder de messages para traduzir o texto do campo `aria-label` no componente [BaseBreadcrumb](https://github.com/vtex-apps/breadcrumb/compare/master...luis-otavio:breadcrumb:master#diff-fa57c40bd82326e019cfab275a80ba0932c8973435e9f2ffc8e53105dc843677).

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://www.samsclub.com.br/vinhos?workspace=accessibilityplp)

Executar teste no Lighthouse ou PageSpeed.

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
Antes da edição:
![image](https://github.com/vtex-apps/breadcrumb/assets/12280996/4cc09fac-4f9e-44af-9d94-6b6a60e06edd)

Após a edição:
![image](https://github.com/vtex-apps/breadcrumb/assets/12280996/6cc27e5a-eed5-4efa-8235-a305d5c1b387)

