### PR TITLE
Add crowdin.yml to integrate the repo with translation tool

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,7 +1,5 @@
-pull_request_title: "[WIP] Do not merge"
-pull_request_labels:
-  - "Localization"
-
+pull_request_title: '[WIP] Do not merge'
+pull_request_labels: ['Localization']
 files:
   - source: "/messages/en.json"
     translation: "/messages/%two_letters_code%.json"

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,7 @@
+pull_request_title: "[WIP] Do not merge"
+pull_request_labels:
+  - "Localization"
+
+files:
+  - source: "/messages/en.json"
+    translation: "/messages/%two_letters_code%.json"


### PR DESCRIPTION
#### What problem is this solving?

This is a follow-up to #108 
It adds a file that allows the repo to integrate with Crowdin (our translation management tool).
**Note: this PR only needs merge, no publish or deploy necessary.**
